### PR TITLE
Fix CVE-2018-17144 based on bitcoin/bitcoin@696b936

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2882,7 +2882,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Check transactions
     for (const auto& tx : block.vtx)
-        if (!CheckTransaction(*tx, state, false))
+        if (!CheckTransaction(*tx, state, true))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
 


### PR DESCRIPTION
Doesn't include the changes to /test/functional/p2p_invalid_block.py since the /test/ folder doesn't exist in Elicoin's source.